### PR TITLE
strings > wordWrap: consider space between words

### DIFF
--- a/app/strings.js
+++ b/app/strings.js
@@ -16,7 +16,7 @@ exports.stringsAnswers = {
         var words = str.split(' '), rows = [];
 
         words.reduce(function (row, current, index) {
-            if (row.length + current.length > cols) {
+            if (row.length + current.length + 1 > cols) {
 
                 if (row) {
                     rows.push(row);
@@ -28,7 +28,13 @@ exports.stringsAnswers = {
 
                 return current;
             } else {
-                return row ? row + ' ' + current : current;
+                if (index === words.length - 1) {
+                    row ? rows.push(row + ' ' + current) : rows.push(current);
+                    return
+                }
+                else {
+                    return row ? row + ' ' + current : current;
+                }
             }
         });
 


### PR DESCRIPTION
If you forget to consider the space between words in your length calculation, you could end up with row that has a length of `cols.length + 1`.  For example, this could happen:

`wordWrap('ab a c ddd', 5)` => `'ab a c\nddd'`

You also have to remember to add the final word in the array.
